### PR TITLE
Fix for start-up error.

### DIFF
--- a/huawei-4g-linux.pl
+++ b/huawei-4g-linux.pl
@@ -12,6 +12,7 @@ use warnings;
 use strict;
 use Getopt::Long;
 use POSIX "WNOHANG";
+use IO::File;
 use IO::Select;
 STDERR->autoflush(1);
 


### PR DESCRIPTION
Tried to use this to get new LMT Huawei E3272 to work (didn't succeed, got it working with NetworkManager), but there was an error on script's start-up ("Can't locate object method "autoflush" via package "IO::File".") on my Gentoo box, this small change fixes that, may save some time for somebody somewhere sometime.
